### PR TITLE
Fix unary minus in expression parser

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1654,6 +1654,7 @@ double EvaluateExpression(const std::string& expression) {
         
         if (expression[i] == '-' && expectingOperand) {
             logDebug("Found unary minus", "CALC");
+            values.push(0.0);
             operators.push('-');
             expectingOperand = true;
             continue;


### PR DESCRIPTION
## Summary
- fix unary minus handling by pushing `0.0` onto the value stack

## Testing
- `g++ -c calculator.cpp`
- `g++ -c main.cpp` *(fails: `windows.h` not found)*